### PR TITLE
Обратный адрес отправителя - не отделение.

### DIFF
--- a/src/Delivery/NovaPoshtaApi2.php
+++ b/src/Delivery/NovaPoshtaApi2.php
@@ -829,6 +829,18 @@ class NovaPoshtaApi2 {
 			$senderWarehouse = $this->getWarehouse($sender['CitySender'], $sender['Warehouse']);
 			$sender['SenderAddress'] = $senderWarehouse['data'][0]['Ref'];
 		}
+                if ( is_array($sender['SenderAddress']) ){
+			$sender['SenderAddress']['CounterpartyRef'] = $sender['Sender'];
+			$Address = $this->model('Address')->save($sender['SenderAddress']);
+            		if ( $Address['success'] ) {
+                		//для создания ттн нужен идентификатор адреса
+                		$sender['SenderAddress'] = $Address['data'][0]['Ref'];
+            		}
+            		elseif ($Address['errors']) {
+                		$error = 'Новая почта сообщает об ошибке: '.(is_array($Address['errors']) ? implode("<br>", $Address['errors']) : $Address['errors']);
+                		throw new CHttpException(400, $error);
+            		}
+		}		
 		if ( ! $sender['Sender']) {
 			$sender['CounterpartyProperty'] = 'Sender';
 			// Set full name to Description if is not set


### PR DESCRIPTION
Позволяет указывать обратный адрес отправителя не почтовое отделение, а простой адрес "ул. Лизы Васюковой, 15".