### PR TITLE
Убрано беспричинное бросение исключения

### DIFF
--- a/src/Delivery/NovaPoshtaApi2.php
+++ b/src/Delivery/NovaPoshtaApi2.php
@@ -192,7 +192,7 @@ class NovaPoshtaApi2
                 ? $data
                 : json_decode($data, true);
             // If error exists, throw Exception
-            if ($this->throwErrors and array_key_exists('errors', $result)) {
+            if ($this->throwErrors and array_key_exists('errors', $result) and $result['errors']) {
                 throw new \Exception(is_array($result['errors']) ? implode("\n", $result['errors']) : $result['errors']);
             }
             return $result;


### PR DESCRIPTION
НП всегда (возможно, не всегда, но как минимум при получении списка городов) возвращает массив в котором ключ 'error' присутствует, но содержит пустой массив (если запрос был успешен). `array_key_exists` убеждается, что ключ существует и бросает исключение с пустым текстом.
Ошибка была сделана здесь #36 